### PR TITLE
Updated mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.2)
@@ -242,4 +244,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
The mimemagic dependency needed to be updated. It is no longer available; old versions were "yanked" due to some licensing issue.

I discovered this when I had the same error message as the OP of this [Stack question](https://stackoverflow.com/questions/66919504/your-bundle-is-locked-to-mimemagic-0-3-5-but-that-version-could-not-be-found).

[Here we can see](https://rubygems.org/gems/mimemagic/versions) that many prior versions of the dependency are no longer available.